### PR TITLE
ユーザーテーブル追加

### DIFF
--- a/src/mysql/initdb.d/1_create_tables.sql
+++ b/src/mysql/initdb.d/1_create_tables.sql
@@ -1,0 +1,16 @@
+USE my_judgment_db;
+
+CREATE TABLE `users`
+(
+    `id`         INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+    `name`       VARCHAR(20) NOT NULL COMMENT 'ユーザー名',
+    `gender`     CHAR(5) DEFAULT NULL COMMENT '性別',
+    `address`    CHAR(5)     NOT NULL COMMENT '所在地',
+    `plan`       int(11) UNSIGNED NOT NULL DEFAULT '0' COMMENT '利用プラン',
+    `created_at` DATETIME    NOT NULL COMMENT '作成日時',
+    `created_by` INT(11) UNSIGNED NOT NULL COMMENT '作成ユーザーID',
+    `updated_at` DATETIME    NOT NULL COMMENT '更新日時',
+    `updated_by` INT(11) UNSIGNED NOT NULL COMMENT '更新ユーザーID',
+    PRIMARY KEY (`id`),
+    UNIQUE `uq_users_1` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT 'ユーザー';


### PR DESCRIPTION
## 概要
- ユーザーテーブル追加

## 詳細
- usersテーブル

```
CREATE TABLE `users`
(
    `id`         INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
    `name`       VARCHAR(20) NOT NULL COMMENT 'ユーザー名',
    `gender`     CHAR(5) DEFAULT NULL COMMENT '性別',
    `address`    CHAR(5)     NOT NULL COMMENT '所在地',
    `plan`       int(11) UNSIGNED NOT NULL DEFAULT '0' COMMENT '利用プラン',
    `created_at` DATETIME    NOT NULL COMMENT '作成日時',
    `created_by` INT(11) UNSIGNED NOT NULL COMMENT '作成ユーザーID',
    `updated_at` DATETIME    NOT NULL COMMENT '更新日時',
    `updated_by` INT(11) UNSIGNED NOT NULL COMMENT '更新ユーザーID',
    PRIMARY KEY (`id`),
    UNIQUE `uq_users_1` (`name`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT 'ユーザー';
```


## 検証方法
ローカル環境でテーブル確認
①`docker-compose down -v`
②`docker-compose up -d`
③`docker ps`
④`docker logs XXX`
⑤`docker exec -it XXX bash`
⑥mysqlに接続
⑦テーブル確認
