### PR TITLE
グループテーブル追加

### DIFF
--- a/src/mysql/initdb.d/1_create_tables.sql
+++ b/src/mysql/initdb.d/1_create_tables.sql
@@ -14,3 +14,19 @@ CREATE TABLE `users`
     PRIMARY KEY (`id`),
     UNIQUE `uq_users_1` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT 'ユーザー';
+
+CREATE TABLE `groups`
+(
+    `id`         INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+    `user_id`    INT(11) UNSIGNED NOT NULL COMMENT 'ユーザーID',
+    `name`       VARCHAR(20) NOT NULL COMMENT 'グループ名',
+    `created_at` DATETIME    NOT NULL COMMENT '作成日時',
+    `created_by` INT(11) UNSIGNED NOT NULL COMMENT '作成ユーザーID',
+    `updated_at` DATETIME    NOT NULL COMMENT '更新日時',
+    `updated_by` INT(11) UNSIGNED NOT NULL COMMENT '更新ユーザーID',
+    PRIMARY KEY (`id`),
+    UNIQUE `uq_groups_1` (`user_id`, `name`),
+    FOREIGN KEY `fk_groups_user_id` (`user_id`)
+        REFERENCES `users` (`id`)
+        ON DELETE RESTRICT ON UPDATE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT 'グループ';


### PR DESCRIPTION
## 概要
- グループテーブル追加

## 詳細
- groupsテーブル

```
CREATE TABLE `groups`
(
    `id`         INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
    `user_id`    INT(11) UNSIGNED NOT NULL COMMENT 'ユーザーID',
    `name`       VARCHAR(20) NOT NULL COMMENT 'グループ名',
    `created_at` DATETIME    NOT NULL COMMENT '作成日時',
    `created_by` INT(11) UNSIGNED NOT NULL COMMENT '作成ユーザーID',
    `updated_at` DATETIME    NOT NULL COMMENT '更新日時',
    `updated_by` INT(11) UNSIGNED NOT NULL COMMENT '更新ユーザーID',
    PRIMARY KEY (`id`),
    UNIQUE `uq_groups_1` (`user_id`, `name`),
    FOREIGN KEY `fk_groups_user_id` (`user_id`)
        REFERENCES `users` (`id`)
        ON DELETE RESTRICT ON UPDATE RESTRICT
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT 'グループ';
```


## 検証方法
ローカル環境でテーブル確認
①`docker-compose down -v`
②`docker-compose up -d`
③`docker ps`
④`docker logs XXX`
⑤`docker exec -it XXX bash`
⑥mysqlに接続
⑦テーブル確認
