### PR TITLE
よく使うアイテムテーブル追加

### DIFF
--- a/src/mysql/initdb.d/1_create_tables.sql
+++ b/src/mysql/initdb.d/1_create_tables.sql
@@ -72,3 +72,17 @@ CREATE TABLE `items`
         REFERENCES `categories` (`id`)
         ON DELETE RESTRICT ON UPDATE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT 'アイテム';
+
+CREATE TABLE `item_favorites`
+(
+    `id`         INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+    `group_id`   INT(11) UNSIGNED NOT NULL COMMENT 'グループID',
+    `item_id`    INT(11) UNSIGNED NOT NULL COMMENT 'アイテムID',
+    `use_count`  INT(11) UNSIGNED NOT NULL DEFAULT 0 COMMENT '使用回数',
+    `created_at` DATETIME NOT NULL COMMENT '作成日時',
+    `created_by` INT(11) UNSIGNED NOT NULL COMMENT '作成ユーザーID',
+    `updated_at` DATETIME NOT NULL COMMENT '更新日時',
+    `updated_by` INT(11) UNSIGNED NOT NULL COMMENT '更新ユーザーID',
+    PRIMARY KEY (`id`),
+    UNIQUE `uq_categories_1` (`group_id`, `item_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT 'よく使うアイテム';


### PR DESCRIPTION
## 概要
- よく使うアイテムテーブル追加

## 詳細
- item_favoritesテーブル

```
CREATE TABLE `item_favorites`
(
    `id`         INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
    `group_id`   INT(11) UNSIGNED NOT NULL COMMENT 'グループID',
    `item_id`    INT(11) UNSIGNED NOT NULL COMMENT 'アイテムID',
    `use_count`  INT(11) UNSIGNED NOT NULL DEFAULT 0 COMMENT '使用回数',
    `created_at` DATETIME NOT NULL COMMENT '作成日時',
    `created_by` INT(11) UNSIGNED NOT NULL COMMENT '作成ユーザーID',
    `updated_at` DATETIME NOT NULL COMMENT '更新日時',
    `updated_by` INT(11) UNSIGNED NOT NULL COMMENT '更新ユーザーID',
    PRIMARY KEY (`id`),
    UNIQUE `uq_categories_1` (`group_id`, `item_id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT 'よく使うアイテム';

```


## 検証方法
ローカル環境でテーブル確認
①`docker-compose down -v`
②`docker-compose up -d`
③`docker ps`
④`docker logs XXX`
⑤`docker exec -it XXX bash`
⑥mysqlに接続
⑦テーブル確認
