### PR TITLE
ロックテーブル追加

### DIFF
--- a/src/mysql/initdb.d/1_create_tables.sql
+++ b/src/mysql/initdb.d/1_create_tables.sql
@@ -2,30 +2,37 @@ USE my_judgment_db;
 
 CREATE TABLE `users`
 (
-    `id`         INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `name`       VARCHAR(20) NOT NULL COMMENT 'ユーザー名',
-    `gender`     CHAR(5) DEFAULT NULL COMMENT '性別',
-    `address`    CHAR(5)     NOT NULL COMMENT '所在地',
-    `plan`       int(11) UNSIGNED NOT NULL DEFAULT '0' COMMENT '利用プラン',
-    `created_at` DATETIME    NOT NULL COMMENT '作成日時',
-    `created_by` INT(11) UNSIGNED NOT NULL COMMENT '作成ユーザーID',
-    `updated_at` DATETIME    NOT NULL COMMENT '更新日時',
-    `updated_by` INT(11) UNSIGNED NOT NULL COMMENT '更新ユーザーID',
+    `id`          INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+    `name`        VARCHAR(20) NOT NULL COMMENT 'ユーザー名',
+    `gender`      CHAR(5) DEFAULT NULL COMMENT '性別',
+    `address`     CHAR(5) NOT NULL COMMENT '所在地',
+    `email`       varchar(255) COLLATE utf8_unicode_ci NOT NULL COMMENT '利用プラン',
+    `plan`        int(11) UNSIGNED NOT NULL DEFAULT '0' COMMENT '利用プラン',
+    `created_at`  DATETIME NOT NULL COMMENT '作成日時',
+    `created_by`  INT(11) UNSIGNED NOT NULL COMMENT '作成ユーザーID',
+    `updated_at`  DATETIME NOT NULL COMMENT '更新日時',
+    `updated_by`  INT(11) UNSIGNED NOT NULL COMMENT '更新ユーザーID',
+    `deleted_at`  DATETIME DEFAULT NULL COMMENT '削除日時',
+    `deleted_by`  INT(11) UNSIGNED DEFAULT NULL COMMENT '削除ユーザーID',
+    `deleted_uts` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT '削除日時UNIX NANOタイムスタンプ',
     PRIMARY KEY (`id`),
-    UNIQUE `uq_users_1` (`name`)
+    UNIQUE `uq_users_1` (`name`, `email`, `deleted_uts`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT 'ユーザー';
 
 CREATE TABLE `groups`
 (
-    `id`         INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `user_id`    INT(11) UNSIGNED NOT NULL COMMENT 'ユーザーID',
-    `name`       VARCHAR(20) NOT NULL COMMENT 'グループ名',
-    `created_at` DATETIME    NOT NULL COMMENT '作成日時',
-    `created_by` INT(11) UNSIGNED NOT NULL COMMENT '作成ユーザーID',
-    `updated_at` DATETIME    NOT NULL COMMENT '更新日時',
-    `updated_by` INT(11) UNSIGNED NOT NULL COMMENT '更新ユーザーID',
+    `id`          INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+    `user_id`     INT(11) UNSIGNED NOT NULL COMMENT 'ユーザーID',
+    `name`        VARCHAR(20) NOT NULL COMMENT 'グループ名',
+    `created_at`  DATETIME    NOT NULL COMMENT '作成日時',
+    `created_by`  INT(11) UNSIGNED NOT NULL COMMENT '作成ユーザーID',
+    `updated_at`  DATETIME    NOT NULL COMMENT '更新日時',
+    `updated_by`  INT(11) UNSIGNED NOT NULL COMMENT '更新ユーザーID',
+    `deleted_at`  DATETIME DEFAULT NULL COMMENT '削除日時',
+    `deleted_by`  INT(11) UNSIGNED DEFAULT NULL COMMENT '削除ユーザーID',
+    `deleted_uts` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT '削除日時UNIX NANOタイムスタンプ',
     PRIMARY KEY (`id`),
-    UNIQUE `uq_groups_1` (`user_id`, `name`),
+    UNIQUE `uq_groups_1` (`user_id`, `name`, `deleted_uts`),
     FOREIGN KEY `fk_groups_user_id` (`user_id`)
         REFERENCES `users` (`id`)
         ON DELETE RESTRICT ON UPDATE RESTRICT
@@ -33,17 +40,20 @@ CREATE TABLE `groups`
 
 CREATE TABLE `categories`
 (
-    `id`         INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `group_id`   INT(11) UNSIGNED NOT NULL COMMENT 'グループID',
-    `name`       VARCHAR(20) NOT NULL COMMENT 'カテゴリー名',
-    `detail`     VARCHAR(40) DEFAULT NULL COMMENT 'カテゴリー詳細',
-    `position`   INT(11) UNSIGNED NOT NULL DEFAULT 0 COMMENT '並び順',
-    `created_at` DATETIME    NOT NULL COMMENT '作成日時',
-    `created_by` INT(11) UNSIGNED NOT NULL COMMENT '作成ユーザーID',
-    `updated_at` DATETIME    NOT NULL COMMENT '更新日時',
-    `updated_by` INT(11) UNSIGNED NOT NULL COMMENT '更新ユーザーID',
+    `id`          INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+    `group_id`    INT(11) UNSIGNED NOT NULL COMMENT 'グループID',
+    `name`        VARCHAR(20) NOT NULL COMMENT 'カテゴリー名',
+    `detail`      VARCHAR(40) DEFAULT NULL COMMENT 'カテゴリー詳細',
+    `position`    INT(11) UNSIGNED NOT NULL DEFAULT 0 COMMENT '並び順',
+    `created_at`  DATETIME    NOT NULL COMMENT '作成日時',
+    `created_by`  INT(11) UNSIGNED NOT NULL COMMENT '作成ユーザーID',
+    `updated_at`  DATETIME    NOT NULL COMMENT '更新日時',
+    `updated_by`  INT(11) UNSIGNED NOT NULL COMMENT '更新ユーザーID',
+    `deleted_at`  DATETIME    DEFAULT NULL COMMENT '削除日時',
+    `deleted_by`  INT(11) UNSIGNED DEFAULT NULL COMMENT '削除ユーザーID',
+    `deleted_uts` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT '削除日時UNIX NANOタイムスタンプ',
     PRIMARY KEY (`id`),
-    UNIQUE `uq_categories_1` (`group_id`, `name`)
+    UNIQUE `uq_categories_1` (`group_id`, `name`, `deleted_uts`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT 'カテゴリー';
 
 CREATE TABLE `items`
@@ -65,9 +75,12 @@ CREATE TABLE `items`
     `trashed_by`       INT(11) UNSIGNED DEFAULT NULL COMMENT 'ゴミ箱に入れたユーザーID',
     `restored_at`      DATETIME DEFAULT NULL COMMENT 'ゴミ箱復元日時',
     `restored_by`      INT(11) UNSIGNED DEFAULT NULL COMMENT 'ゴミ箱復元ユーザーID',
+    `deleted_at`       DATETIME DEFAULT NULL COMMENT '削除日時',
+    `deleted_by`       INT(11) UNSIGNED DEFAULT NULL COMMENT '削除ユーザーID',
+    `deleted_uts`      BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT '削除日時UNIX NANOタイムスタンプ',
     PRIMARY KEY (`id`),
-    KEY `index_items_1` (`group_id`, `category_id`),
-    UNIQUE `uq_items_1` (`group_id`, `category_id`, `name`),
+    KEY `index_items_1` (`group_id`, `deleted_uts`, `category_id`),
+    UNIQUE `uq_items_1` (`group_id`, `category_id`, `name`, `deleted_uts`),
     FOREIGN KEY `fk_items_category_id` (`category_id`)
         REFERENCES `categories` (`id`)
         ON DELETE RESTRICT ON UPDATE RESTRICT
@@ -75,14 +88,38 @@ CREATE TABLE `items`
 
 CREATE TABLE `item_favorites`
 (
-    `id`         INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `group_id`   INT(11) UNSIGNED NOT NULL COMMENT 'グループID',
-    `item_id`    INT(11) UNSIGNED NOT NULL COMMENT 'アイテムID',
-    `use_count`  INT(11) UNSIGNED NOT NULL DEFAULT 0 COMMENT '使用回数',
-    `created_at` DATETIME NOT NULL COMMENT '作成日時',
-    `created_by` INT(11) UNSIGNED NOT NULL COMMENT '作成ユーザーID',
-    `updated_at` DATETIME NOT NULL COMMENT '更新日時',
-    `updated_by` INT(11) UNSIGNED NOT NULL COMMENT '更新ユーザーID',
+    `id`          INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+    `group_id`    INT(11) UNSIGNED NOT NULL COMMENT 'グループID',
+    `item_id`     INT(11) UNSIGNED NOT NULL COMMENT 'アイテムID',
+    `use_count`   INT(11) UNSIGNED NOT NULL DEFAULT 0 COMMENT '使用回数',
+    `created_at`  DATETIME NOT NULL COMMENT '作成日時',
+    `created_by`  INT(11) UNSIGNED NOT NULL COMMENT '作成ユーザーID',
+    `updated_at`  DATETIME NOT NULL COMMENT '更新日時',
+    `updated_by`  INT(11) UNSIGNED NOT NULL COMMENT '更新ユーザーID',
+    `deleted_at`  DATETIME DEFAULT NULL COMMENT '削除日時',
+    `deleted_by`  INT(11) UNSIGNED DEFAULT NULL COMMENT '削除ユーザーID',
+    `deleted_uts` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT '削除日時UNIX NANOタイムスタンプ',
     PRIMARY KEY (`id`),
-    UNIQUE `uq_categories_1` (`group_id`, `item_id`)
+    UNIQUE `uq_categories_1` (`group_id`, `item_id`, `deleted_uts`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT 'よく使うアイテム';
+
+CREATE TABLE `locks`
+(
+    `id`          INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+    `group_id`    INT(11) UNSIGNED NOT NULL COMMENT 'グループID',
+    `type`        VARCHAR(5)  NOT NULL COMMENT 'ロックタイプ',
+    `target`      VARCHAR(30) NOT NULL COMMENT 'ロック対象',
+    `target_id`   INT(11) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'ロック対象ID',
+    `expires_uts` INT(11) NOT NULL DEFAULT 0 COMMENT 'ロック有効期限UNIXタイムスタンプ',
+    `device`      VARCHAR(64) NOT NULL COMMENT 'ロックデバイス名',
+    `created_at`  DATETIME    NOT NULL COMMENT '作成日時',
+    `created_by`  INT(11) UNSIGNED NOT NULL COMMENT '作成ユーザーID',
+    `updated_at`  DATETIME    NOT NULL COMMENT '更新日時',
+    `updated_by`  INT(11) UNSIGNED NOT NULL COMMENT '更新ユーザーID',
+    `deleted_at`  DATETIME DEFAULT NULL COMMENT '削除日時',
+    `deleted_by`  INT(11) UNSIGNED DEFAULT NULL COMMENT '削除ユーザーID',
+    `deleted_uts` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT '削除日時UNIX NANOタイムスタンプ',
+    PRIMARY KEY (`id`),
+    UNIQUE `uq_locks_1` (`group_id`, `deleted_uts`, `type`, `target`, `target_id`, `expires_uts`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT 'ロック';
+


### PR DESCRIPTION
## 概要
- ロックテーブル追加

## 詳細
- locksテーブル
- 各テーブルに`deleted_at`,`deleted_by`,`deleted_uts`カラムを追加

```
CREATE TABLE `locks`
(
    `id`          INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
    `group_id`    INT(11) UNSIGNED NOT NULL COMMENT 'グループID',
    `type`        VARCHAR(5)  NOT NULL COMMENT 'ロックタイプ',
    `target`      VARCHAR(30) NOT NULL COMMENT 'ロック対象',
    `target_id`   INT(11) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'ロック対象ID',
    `expires_uts` INT(11) NOT NULL DEFAULT 0 COMMENT 'ロック有効期限UNIXタイムスタンプ',
    `device`      VARCHAR(64) NOT NULL COMMENT 'ロックデバイス名',
    `created_at`  DATETIME    NOT NULL COMMENT '作成日時',
    `created_by`  INT(11) UNSIGNED NOT NULL COMMENT '作成ユーザーID',
    `updated_at`  DATETIME    NOT NULL COMMENT '更新日時',
    `updated_by`  INT(11) UNSIGNED NOT NULL COMMENT '更新ユーザーID',
    `deleted_at`  DATETIME DEFAULT NULL COMMENT '削除日時',
    `deleted_by`  INT(11) UNSIGNED DEFAULT NULL COMMENT '削除ユーザーID',
    `deleted_uts` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT '削除日時UNIX NANOタイムスタンプ',
    PRIMARY KEY (`id`),
    UNIQUE `uq_locks_1` (`group_id`, `deleted_uts`, `type`, `target`, `target_id`, `expires_uts`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT 'ロック';
```


## 検証方法
ローカル環境でテーブル確認
①`docker-compose down -v`
②`docker-compose up -d`
③`docker ps`
④`docker logs XXX`
⑤`docker exec -it XXX bash`
⑥mysqlに接続
⑦テーブル確認
