### PR TITLE
ユーザー系APIのswaggerにパスパラメータ追加

### DIFF
--- a/swagger/web/user.yaml
+++ b/swagger/web/user.yaml
@@ -35,6 +35,7 @@ paths:
       tags: [ User ]
       parameters:
         - $ref: '#/components/parameters/paramApiVersion'
+        - $ref: '#/components/parameters/paramMjUserID'
       responses:
         200:
           $ref: "#/components/responses/getMjUserResp"
@@ -52,6 +53,7 @@ paths:
       tags: [ User ]
       parameters:
         - $ref: '#/components/parameters/paramApiVersion'
+        - $ref: '#/components/parameters/paramMjUserID'
       requestBody:
         $ref: "#/components/requestBodies/putMjUserReq"
       responses:
@@ -78,6 +80,16 @@ components:
       schema:
         type: string
         example: "1.0"
+
+    paramMjUserID:
+      name: userID
+      in: path
+      required: true
+      schema:
+        type: integer
+        minimum: 1
+        exclusiveMaximum: true
+        example: 1
 
   requestBodies:
     postMjUserReq:


### PR DESCRIPTION
## 概要
- ユーザー系APIのswaggerにパスパラメータ追加

## 詳細
- `userID`追加

[swaggerコード](https://github.com/kazumakawahara/my-judgment/blob/feat/modify-user-swagger/swagger/web/user.yaml)

## 検証方法
- Swagger UIにて確認
