### PR TITLE
usersテーブルにpasswordカラム追加

### DIFF
--- a/src/mysql/initdb.d/1_create_tables.sql
+++ b/src/mysql/initdb.d/1_create_tables.sql
@@ -7,7 +7,8 @@ CREATE TABLE `users`
     `birthday`    DATETIME NOT NULL COMMENT '誕生日',
     `gender`      CHAR(5) NOT NULL COMMENT '性別',
     `address`     CHAR(5) NOT NULL COMMENT '所在地',
-    `email`       varchar(255) COLLATE utf8_unicode_ci NOT NULL COMMENT '利用プラン',
+    `email`       varchar(255) COLLATE utf8_unicode_ci NOT NULL COMMENT 'メールアドレス',
+    `password`    varchar(16)  NOT NULL COMMENT 'パスワード',
     `plan`        int(11) UNSIGNED NOT NULL DEFAULT '0' COMMENT '利用プラン',
     `created_at`  DATETIME NOT NULL COMMENT '作成日時',
     `created_by`  INT(11) UNSIGNED NOT NULL COMMENT '作成ユーザーID',
@@ -15,9 +16,9 @@ CREATE TABLE `users`
     `updated_by`  INT(11) UNSIGNED NOT NULL COMMENT '更新ユーザーID',
     `deleted_at`  DATETIME DEFAULT NULL COMMENT '削除日時',
     `deleted_by`  INT(11) UNSIGNED DEFAULT NULL COMMENT '削除ユーザーID',
-    `deleted_uts` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT '削除日時UNIX NANOタイムスタンプ',
     PRIMARY KEY (`id`),
-    UNIQUE `uq_users_1` (`name`, `email`, `deleted_uts`)
+    UNIQUE `uq_users_1` (`name`, `email`),
+    UNIQUE `uq_users_2` (`password`, `deleted_uts`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT 'ユーザー';
 
 CREATE TABLE `groups`

--- a/src/mysql/initdb.d/1_create_tables.sql
+++ b/src/mysql/initdb.d/1_create_tables.sql
@@ -16,9 +16,10 @@ CREATE TABLE `users`
     `updated_by`  INT(11) UNSIGNED NOT NULL COMMENT '更新ユーザーID',
     `deleted_at`  DATETIME DEFAULT NULL COMMENT '削除日時',
     `deleted_by`  INT(11) UNSIGNED DEFAULT NULL COMMENT '削除ユーザーID',
+    `deleted_uts` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT '削除日時UNIX NANOタイムスタンプ',
     PRIMARY KEY (`id`),
-    UNIQUE `uq_users_1` (`name`, `email`),
-    UNIQUE `uq_users_2` (`password`, `deleted_uts`)
+    KEY `index_users_1` (`name`, `email`),
+    UNIQUE `uq_users_1` (`email`, `deleted_uts`),
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT 'ユーザー';
 
 CREATE TABLE `groups`


### PR DESCRIPTION
## 概要
- `password`カラム追加

## 詳細
- usersテーブル

```
CREATE TABLE `users`
(
    `id`          INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
    `name`        VARCHAR(20) NOT NULL COMMENT 'ユーザー名',
    `birthday`    DATETIME NOT NULL COMMENT '誕生日',
    `gender`      CHAR(5) NOT NULL COMMENT '性別',
    `address`     CHAR(5) NOT NULL COMMENT '所在地',
    `email`       varchar(255) COLLATE utf8_unicode_ci NOT NULL COMMENT 'メールアドレス',
    `password`    varchar(16)  NOT NULL COMMENT 'パスワード',
    `plan`        int(11) UNSIGNED NOT NULL DEFAULT '0' COMMENT '利用プラン',
    `created_at`  DATETIME NOT NULL COMMENT '作成日時',
    `created_by`  INT(11) UNSIGNED NOT NULL COMMENT '作成ユーザーID',
    `updated_at`  DATETIME NOT NULL COMMENT '更新日時',
    `updated_by`  INT(11) UNSIGNED NOT NULL COMMENT '更新ユーザーID',
    `deleted_at`  DATETIME DEFAULT NULL COMMENT '削除日時',
    `deleted_by`  INT(11) UNSIGNED DEFAULT NULL COMMENT '削除ユーザーID',
    `deleted_uts` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT '削除日時UNIX NANOタイムスタンプ',
    PRIMARY KEY (`id`),
    KEY `index_users_1` (`name`, `email`),
    UNIQUE `uq_users_1` (`email`, `deleted_uts`),
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT 'ユーザー';
```


## 検証方法
ローカル環境でテーブル確認
①`docker-compose down -v`
②`docker-compose up -d`
③`docker ps`
④`docker logs XXX`
⑤`docker exec -it XXX bash`
⑥mysqlに接続
⑦テーブル確認
